### PR TITLE
docs: add required github.org entry to boilerplate and README for terragrunt scaffold

### DIFF
--- a/.boilerplate/inputs.yaml
+++ b/.boilerplate/inputs.yaml
@@ -2,6 +2,12 @@
 # All values here are module-specific; framework values (org, spoke_def, is_hub, extra_tags)
 # are injected automatically by the Terragrunt hierarchy.
 
+# (Required) GitHub provider configuration.
+# Used by the generated Terragrunt provider block to set the GitHub provider owner,
+# scoping all API calls to the specified organization.
+github:
+  org: ""  # (Required) GitHub organization name (e.g., "my-org"). Used as the provider owner.
+
 # (Optional) List of GitHub Actions organization-level variables to create.
 # Each entry is an object with the following attributes:
 #   name:       (Required) Name of the variable. Must be unique within the organization.

--- a/.boilerplate/terragrunt.hcl
+++ b/.boilerplate/terragrunt.hcl
@@ -24,6 +24,17 @@ include "root" {
   path = find_in_parent_folders("{{ .RootFileName }}")
 }
 
+# generate github provider block
+generate "provider_github" {
+  path      = "provider.l.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<EOF
+provider "github" {
+  owner = "${local.local_vars.github.org}"
+}
+EOF
+}
+
 terraform {
   source = "{{ .sourceUrl }}"
 }

--- a/README.md
+++ b/README.md
@@ -232,8 +232,8 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_github"></a> [github](#provider\_github) | 6.12.1 |
-| <a name="provider_sodium"></a> [sodium](#provider\_sodium) | 0.0.3 |
+| <a name="provider_github"></a> [github](#provider\_github) | ~> 6.0 |
+| <a name="provider_sodium"></a> [sodium](#provider\_sodium) | >= 0.0.3 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ terragrunt apply
 #### `inputs.yaml` — annotated example
 
 ```yaml
+# (Required) GitHub provider configuration.
+# Used by the generated Terragrunt provider block to set the GitHub provider owner,
+# scoping all API calls to the specified organization.
+github:
+  org: "my-org"  # (Required) GitHub organization name. Used as the provider owner.
+
 # (Optional) List of GitHub Actions organization-level variables to create.
 # Each entry is an object with the following attributes:
 #   name:       (Required) Name of the variable. Must be unique within the organization.
@@ -138,6 +144,18 @@ locals {
 
 include "root" {
   path = find_in_parent_folders("root.hcl")
+}
+
+# Generates the GitHub provider block using github.org from inputs.yaml.
+# github.org is REQUIRED in inputs.yaml for the provider to be configured correctly.
+generate "provider_github" {
+  path      = "provider.l.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<EOF
+provider "github" {
+  owner = "${local.local_vars.github.org}"
+}
+EOF
 }
 
 terraform {
@@ -214,8 +232,8 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_github"></a> [github](#provider\_github) | ~> 6.0 |
-| <a name="provider_sodium"></a> [sodium](#provider\_sodium) | >= 0.0.3 |
+| <a name="provider_github"></a> [github](#provider\_github) | 6.12.1 |
+| <a name="provider_sodium"></a> [sodium](#provider\_sodium) | 0.0.3 |
 
 ## Modules
 

--- a/README.yaml
+++ b/README.yaml
@@ -56,6 +56,12 @@ usage: |-
   #### `inputs.yaml` — annotated example
 
   ```yaml
+  # (Required) GitHub provider configuration.
+  # Used by the generated Terragrunt provider block to set the GitHub provider owner,
+  # scoping all API calls to the specified organization.
+  github:
+    org: "my-org"  # (Required) GitHub organization name. Used as the provider owner.
+
   # (Optional) List of GitHub Actions organization-level variables to create.
   # Each entry is an object with the following attributes:
   #   name:       (Required) Name of the variable. Must be unique within the organization.
@@ -111,6 +117,18 @@ usage: |-
 
   include "root" {
     path = find_in_parent_folders("root.hcl")
+  }
+
+  # Generates the GitHub provider block using github.org from inputs.yaml.
+  # github.org is REQUIRED in inputs.yaml for the provider to be configured correctly.
+  generate "provider_github" {
+    path      = "provider.l.tf"
+    if_exists = "overwrite_terragrunt"
+    contents  = <<EOF
+  provider "github" {
+    owner = "${local.local_vars.github.org}"
+  }
+  EOF
   }
 
   terraform {

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -10,8 +10,8 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_github"></a> [github](#provider\_github) | ~> 6.0 |
-| <a name="provider_sodium"></a> [sodium](#provider\_sodium) | >= 0.0.3 |
+| <a name="provider_github"></a> [github](#provider\_github) | 6.12.1 |
+| <a name="provider_sodium"></a> [sodium](#provider\_sodium) | 0.0.3 |
 
 ## Modules
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -10,8 +10,8 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_github"></a> [github](#provider\_github) | 6.12.1 |
-| <a name="provider_sodium"></a> [sodium](#provider\_sodium) | 0.0.3 |
+| <a name="provider_github"></a> [github](#provider\_github) | ~> 6.0 |
+| <a name="provider_sodium"></a> [sodium](#provider\_sodium) | >= 0.0.3 |
 
 ## Modules
 


### PR DESCRIPTION
## Summary

- Add `github.org` required field to `.boilerplate/inputs.yaml` — the terragrunt.hcl provider block reads `local.local_vars.github.org` to set the GitHub provider `owner`; without this entry scaffolded deployments fail at plan
- Updated `.boilerplate/terragrunt.hcl` adds a `generate "provider_github"` block sourcing `github.org` from `inputs.yaml`
- Document the `github.org` requirement in `README.yaml` usage section with annotated `inputs.yaml` and generated `terragrunt.hcl` examples
- Regenerated `README.md`

+semver: patch